### PR TITLE
Add brand colours and a layout component

### DIFF
--- a/components/QuizOption.jsx
+++ b/components/QuizOption.jsx
@@ -1,7 +1,7 @@
 export default function QuizOption({ option }) {
   return (
     <div className="p-4 bg-green-600 hover:bg-green-800 text-white rounded">
-      {option}
+      {option} Hello
     </div>
   )
 }

--- a/components/withLayout.jsx
+++ b/components/withLayout.jsx
@@ -1,0 +1,25 @@
+import Head from 'next/head'
+
+export default function withLayout(PageComponent) {
+  const PageComponentWithLayout = ({ ...pageProps }) => {
+    return (
+      <>
+        <Head>
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+
+        <nav className="p-4 mb-4 border-b-2 border-gray-100">
+          <div>League Tracker</div>
+        </nav>
+
+        <PageComponent {...pageProps} />
+      </>
+    )
+  }
+
+  return PageComponentWithLayout
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,8 +1,9 @@
 import Head from 'next/head'
 
+import withLayout from '../components/withLayout'
 import QuizOption from '../components/QuizOption'
 
-export default function Home() {
+function Home() {
   return (
     <div>
       <Head>
@@ -20,3 +21,5 @@ export default function Home() {
     </div>
   )
 }
+
+export default withLayout(Home)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,8 +2,23 @@ module.exports = {
   purge: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   darkMode: false, // or 'media' or 'class'
   theme: {
+    fontFamily: {
+      sans: ['Noto Sans', 'sans-serif'],
+    },
     extend: {
-      colors: {},
+      colors: {
+        'brand-blurple-light': '#EDE8FA',
+        'brand-blurple-med': '#B9A4ED',
+        'brand-blurple': '#501CD2',
+        'brand-teal-light': '#E8F8F5',
+        'brand-teal': '#01C3A2',
+        'brand-teal-dark': '#00A886',
+        'brand-blue-light': '#EAEEFB',
+        'brand-blue': '#2E5CDF',
+        'brand-red-light': '#F9DEE3',
+        'brand-red': '#D92045',
+        'brand-red-dark': '#BA1B3B',
+      },
     },
   },
   variants: {


### PR DESCRIPTION
This PR:
- [x] Adds brand colours to the Tailwind config
- [x] Adds a `withLayout` higher order component for nav 